### PR TITLE
Update module to Zig 0.13.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+zig-out/
+.zig-cache/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # Comptime HashMap
+
 A statically initiated HashMap, originally a pull request to the Zig std lib [#5359](https://github.com/ziglang/zig/pull/5359).
+
+## Installation
+
+Build for Zig `0.13.0`.
+
+```sh
+zig fetch --save git+https://github.com/Vexu/comptime_hash_map
+```
+
+In your `build.zig`:
+```zig
+const chm = b.dependency("comptime_hash_map", .{});
+exe.root_module.addImport("comptime_hash_map", chm.module("comptime_hash_map"));
+```
+
+In your `exe` module:
+```zig
+const chm = @import("comptime_hash_map");
+```

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,31 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const lib = b.addStaticLibrary(.{
+        .name = "comptime_hash_map",
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    b.installArtifact(lib);
+
+    const lib_unit_tests = b.addTest(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
+
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_lib_unit_tests.step);
+
+    // https://ziggit.dev/t/how-to-package-a-zig-source-module-and-how-to-use-it/3457
+    _ = b.addModule("comptime_hash_map", .{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,72 @@
+.{
+    // This is the default name used by packages depending on this one. For
+    // example, when a user runs `zig fetch --save <url>`, this field is used
+    // as the key in the `dependencies` table. Although the user can choose a
+    // different name, most users will stick with this provided value.
+    //
+    // It is redundant to include "zig" in this name because it is already
+    // within the Zig package namespace.
+    .name = "comptime_hash_map",
+
+    // This is a [Semantic Version](https://semver.org/).
+    // In a future version of Zig it will be used for package deduplication.
+    .version = "0.0.0",
+
+    // This field is optional.
+    // This is currently advisory only; Zig does not yet do anything
+    // with this value.
+    //.minimum_zig_version = "0.11.0",
+
+    // This field is optional.
+    // Each dependency must either provide a `url` and `hash`, or a `path`.
+    // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
+    // Once all dependencies are fetched, `zig build` no longer requires
+    // internet connectivity.
+    .dependencies = .{
+        // See `zig fetch --save <url>` for a command-line interface for adding dependencies.
+        //.example = .{
+        //    // When updating this field to a new URL, be sure to delete the corresponding
+        //    // `hash`, otherwise you are communicating that you expect to find the old hash at
+        //    // the new URL.
+        //    .url = "https://example.com/foo.tar.gz",
+        //
+        //    // This is computed from the file contents of the directory of files that is
+        //    // obtained after fetching `url` and applying the inclusion rules given by
+        //    // `paths`.
+        //    //
+        //    // This field is the source of truth; packages do not come from a `url`; they
+        //    // come from a `hash`. `url` is just one of many possible mirrors for how to
+        //    // obtain a package matching this `hash`.
+        //    //
+        //    // Uses the [multihash](https://multiformats.io/multihash/) format.
+        //    .hash = "...",
+        //
+        //    // When this is provided, the package is found in a directory relative to the
+        //    // build root. In this case the package's hash is irrelevant and therefore not
+        //    // computed. This field and `url` are mutually exclusive.
+        //    .path = "foo",
+
+        //    // When this is set to `true`, a package is declared to be lazily
+        //    // fetched. This makes the dependency only get fetched if it is
+        //    // actually used.
+        //    .lazy = false,
+        //},
+    },
+
+    // Specifies the set of files and directories that are included in this package.
+    // Only files and directories listed here are included in the `hash` that
+    // is computed for this package. Only files listed here will remain on disk
+    // when using the zig package manager. As a rule of thumb, one should list
+    // files required for compilation plus any license(s).
+    // Paths are relative to the build root. Use the empty string (`""`) to refer to
+    // the build root itself.
+    // A directory listed here means that all files within, recursively, are included.
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        // For example...
+        //"LICENSE",
+        //"README.md",
+    },
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -5,12 +5,7 @@ const math = std.math;
 
 /// A comptime hashmap constructed with automatically selected hash and eql functions.
 pub fn AutoComptimeHashMap(comptime K: type, comptime V: type, comptime values: anytype) type {
-    return ComptimeHashMap(
-        K,
-        V,
-        hash_map.AutoContext(K),
-        values,
-    );
+    return ComptimeHashMap(K, V, hash_map.AutoContext(K), values);
 }
 
 /// Builtin hashmap for strings as keys.

--- a/src/main.zig
+++ b/src/main.zig
@@ -47,7 +47,7 @@ pub fn ComptimeHashMap(comptime K: type, comptime V: type, comptime ctx: type, c
             const index = (start_index + roll_over) & (size - 1);
             const entry = &slots[index];
 
-            if (entry.used and !ctx.eql(entry.key, key)) {
+            if (entry.used and !ctx.eql(undefined, entry.key, key)) {
                 if (entry.distance_from_start_index < distance_from_start_index) {
                     // robin hood to the rescue
                     const tmp = slots[index];


### PR DESCRIPTION
- Add new build.zig and build.zig.zon.
- Update module to use `hash_map.AutoContext` and `hash_map.StringContext`, passing `undefined` to `eql` and `hash`.